### PR TITLE
Upgrade lib js to latest version (0.6.4)

### DIFF
--- a/lib/msal_js.dart
+++ b/lib/msal_js.dart
@@ -8,6 +8,8 @@
 library msal_js;
 
 import 'dart:async';
+import 'dart:js';
+import 'dart:js_util';
 
 import 'package:js/js.dart';
 import 'package:js/js_util.dart';

--- a/lib/src/js_proxies/js_proxies.dart
+++ b/lib/src/js_proxies/js_proxies.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:js_util';
 
 import 'package:js/js_util.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  js: ^0.6.3
+  js: ^0.6.4
 
 dev_dependencies:
   lints: ^1.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: msal_js
 description: "A Dart wrapper for the 'Microsoft Authentication Library for JavaScript (MSAL.js)'."
-version: 2.14.0
+version: 2.14.1
 homepage: https://github.com/Francessco121/msal-js-dart
 repository: https://github.com/Francessco121/msal-js-dart
 issue_tracker: https://github.com/Francessco121/msal-js-dart/issues

--- a/test/exceptions_test.dart
+++ b/test/exceptions_test.dart
@@ -6,7 +6,6 @@ library exceptions_test;
 // of them, even tho more than what is exported is thrown...
 
 import 'package:js/js.dart';
-import 'package:msal_js/msal_js.dart';
 import 'package:msal_js/src/exceptions.dart';
 import 'package:msal_js/src/interop/interop.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
This PR updates the `js` library used by `msal_js` to the latest version `0.6.4` and adds in the required `dart:js`, `dart:js_util` imports. 

These changes allow `msal_js` to be used with other libraries depending on `js v0.6.4` (such as `go_router`)

A minor version bump was added to bring `msal_js` to version `2.14.1` 